### PR TITLE
docs: update for new new extension listing guidelines/fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "lang-go",
-  "title": "Code intelligence for Go",
-  "description": "Provides code intelligence for Go",
+  "description": "Go code intelligence",
   "publisher": "sourcegraph",
   "activationEvents": [
     "onLanguage:go"
@@ -10,6 +9,8 @@
     "type": "git",
     "url": "https://github.com/sourcegraph/lang-go"
   },
+  "categories": ["Programming languages"],
+  "tags": ["go", "cross-repository", "language-server"],
   "contributes": {
     "actions": [
       {


### PR DESCRIPTION
Updates to reflect the changes to extension listings on the extension registry in https://github.com/sourcegraph/sourcegraph/pull/1612:

- Extensions can have tags and categories.
- Extensions no longer have titles. The extension ID, `sourcegraph/lang-go`, and the extension description are the only things shown now.
- The extension description can/should be shorter now that it's shown on 1 line and there is no title.